### PR TITLE
Some changes for PurpleOps after internal PoC

### DIFF
--- a/blueprints/assessment_export.py
+++ b/blueprints/assessment_export.py
@@ -110,7 +110,7 @@ def exportreport(id):
     doc.render({
         "assessment": assessment,
         "testcases": testcases
-    })
+    }, autoescape=True)
     doc.save(f'files/{id}/report.docx')
 
     return send_from_directory('files', f"{id}/report.docx", as_attachment=True)

--- a/blueprints/assessment_export.py
+++ b/blueprints/assessment_export.py
@@ -66,7 +66,7 @@ def exportcampaign(id):
         # Generate a full JSON dump but then filter to only the applicable fields
         fullJson = testcase.to_json(raw=True)
         campaignJson = {}
-        for field in ["mitreid", "tactic", "name", "objective", "actions", "tools", "uuid", "tags"]:
+        for field in ["mitreid", "tactic", "name", "objective", "actions", "tools", "uuid", "tags", "priority", "priorityurgency", "expectedalertseverity"]:
             campaignJson[field] = fullJson[field]
         jsonDict.append(campaignJson)
 

--- a/blueprints/assessment_export.py
+++ b/blueprints/assessment_export.py
@@ -155,33 +155,38 @@ def exportnavigator(id):
         "selectSubtechniquesWithParent": False
     }
 
-    for technique in Technique.objects().all():
-        if current_user.has_role("Blue"):
-            testcases = TestCase.objects(assessmentid=id, visible=True, mitreid=technique.mitreid).all()
-        else:
-            testcases = TestCase.objects(assessmentid=id, mitreid=technique.mitreid).all()
-        ttp = {
-            "techniqueID": technique.mitreid
-        }
+    if current_user.has_role("Blue"):
+        testcases = TestCase.objects(assessmentid=id, visible=True).all()
+    else:
+        testcases = TestCase.objects(assessmentid=id).all()
 
-        if testcases:
+    results = {}
+    for testcase in testcases:
+        if not testcase.tactic in results:
+                results[testcase.tactic] = {}
+        
+        if not testcase.mitreid in results[testcase.tactic]:
+                results[testcase.tactic][testcase.mitreid] = {"Prevented and Alerted": 0, "Prevented": 0, "Alerted": 0, "Logged": 0, "Missed": 0}
+
+        if testcase.outcome in results[testcase.tactic][testcase.mitreid].keys():
+            results[testcase.tactic][testcase.mitreid][testcase.outcome] += 1  
+
+    for tactic_key, techniques in results.items():
+        for technique_key,outcomes in techniques.items():
             count = 0
-            outcomes = {"Prevented": 0, "Alerted": 0, "Logged": 0, "Missed": 0}
-            for testcase in testcases:
-                if testcase.outcome in outcomes.keys():
-                    count += 1
-                    outcomes[testcase.outcome] += 1
+            for outcome_key, outcome in outcomes.items():
+                count += outcome
 
             if count:
-                score = int((outcomes["Prevented"] * 3 + outcomes["Alerted"] * 2 +
-                            outcomes["Logged"]) / (count * 3) * 100)
-                ttp["score"] = score
-
-            for tactic in technique.tactics:
-                tactic = tactic.lower().strip().replace(" ", "-")
-                tacticTTP = dict(ttp)
-                tacticTTP["tactic"] = tactic
-                navigator["techniques"].append(tacticTTP)
+                score = int((outcomes["Prevented and Alerted"] * 4 + outcomes["Prevented"] * 3 + outcomes["Alerted"] * 2 +
+                            outcomes["Logged"]) / (count * 4) * 100)
+            
+                ttp = {
+                    "techniqueID": technique_key, 
+                    "tactic": tactic_key.lower().strip().replace(" ", "-"),
+                    "score": score
+                }
+                navigator["techniques"].append(ttp)
 
     with open(f'files/{id}/navigator.json', 'w') as f:
         json.dump(navigator, f, indent=4)  

--- a/blueprints/assessment_export.py
+++ b/blueprints/assessment_export.py
@@ -37,7 +37,7 @@ def exportassessment(id, filetype):
     
     # Otherwise flatten JSON arrays into comma delimited strings
     for t, testcase in enumerate(jsonDict):
-        for field in ["sources", "targets", "tools", "controls", "tags", "redfiles", "bluefiles"]:
+        for field in ["sources", "targets", "tools", "controls", "tags", "preventionsources", "detectionsources", "redfiles", "bluefiles"]:
             jsonDict[t][field] = ",".join(testcase[field])
 
     # Convert the JSON dict to CSV and deliver

--- a/blueprints/assessment_import.py
+++ b/blueprints/assessment_import.py
@@ -25,6 +25,9 @@ def testcasetemplates(id):
             objective = template.objective,
             actions = template.actions,
             rednotes = template.rednotes,
+            priority = template.priority,
+            priorityurgency = template.priorityurgency,
+            expectedalertseverity = template.expectedalertseverity,
             assessmentid = id
         ).save()
         newcases.append(newcase.to_json())
@@ -72,7 +75,7 @@ def testcasecampaign(id):
     for testcase in campaignTestcases:
         newcase = TestCase()
         newcase.assessmentid = id
-        for field in ["name", "mitreid", "tactic", "objective", "actions", "tools", "uuid", "tags"]:
+        for field in ["name", "mitreid", "tactic", "objective", "actions", "tools", "uuid", "tags", "priority", "priorityurgency", "expectedalertseverity"]:
             if field in testcase:
                 if field not in ["tools", "tags"]:
                     newcase[field] = testcase[field]
@@ -142,7 +145,7 @@ def importentire():
         for field in ["name", "objective", "actions", "rednotes", "bluenotes",
                       "uuid", "mitreid", "tactic", "state", "prevented", "preventedrating",
                       "alerted", "alertseverity", "logged", "detectionrating",
-                      "priority", "priorityurgency", "visible", "outcome"]:
+                      "priority", "priorityurgency", "expectedalertseverity", "visible", "outcome"]:
             newTestcase[field] = oldTestcase[field]
 
         for field in ["starttime", "endtime", "detecttime", "modifytime", "alerttime", "preventtime"]:

--- a/blueprints/assessment_import.py
+++ b/blueprints/assessment_import.py
@@ -128,7 +128,9 @@ def importentire():
         "targets": {},
         "tools": {},
         "controls": {},
-        "tags": {}
+        "tags": {},
+        "preventionsources": {},
+        "detectionsources": {}
     }
 
     for oldTestcase in export:
@@ -147,7 +149,7 @@ def importentire():
             if oldTestcase[field] != "None":
                 newTestcase[field] = datetime.datetime.strptime(oldTestcase[field].split(".")[0], "%Y-%m-%d %H:%M:%S")
 
-        for field in ["sources", "targets", "tools", "controls", "tags"]:
+        for field in ["sources", "targets", "tools", "controls", "tags", "preventionsources", "detectionsources"]:
             newTestcase[field] = []
             
             for multi in oldTestcase[field]:
@@ -165,6 +167,10 @@ def importentire():
                         newMulti = Control(name=name, description=details)
                     elif field == "tags":
                         newMulti = Tag(name=name, colour=details)
+                    elif field == "preventionsources":
+                        newMulti = Preventionsource(name=name, description=details)
+                    elif field == "detectionsources":
+                        newMulti = Detectionsource(name=name, description=details)
                     assessment[field].append(newMulti)
                     assessment[field].save()
                     assessmentMultis[field][f"{newMulti.name}|{newMulti.description if field != 'tags' else newMulti.colour}"] = str(assessment[field][-1].id)

--- a/blueprints/assessment_import.py
+++ b/blueprints/assessment_import.py
@@ -145,7 +145,7 @@ def importentire():
                       "priority", "priorityurgency", "visible", "outcome"]:
             newTestcase[field] = oldTestcase[field]
 
-        for field in ["starttime", "endtime", "detecttime", "modifytime"]:
+        for field in ["starttime", "endtime", "detecttime", "modifytime", "alerttime", "preventtime"]:
             if oldTestcase[field] != "None":
                 newTestcase[field] = datetime.datetime.strptime(oldTestcase[field].split(".")[0], "%Y-%m-%d %H:%M:%S")
 

--- a/blueprints/assessment_utils.py
+++ b/blueprints/assessment_utils.py
@@ -96,7 +96,7 @@ def assessmentstats(id):
     # Initalise metrics that are captured
     stats = {
         "All": {
-            "Prevented": 0, "Alerted": 0, "Logged": 0, "Missed": 0,
+            "Prevented and Alerted": 0, "Prevented": 0, "Alerted": 0, "Logged": 0, "Missed": 0,
             "Critical": 0, "High": 0, "Medium": 0, "Low": 0, "Informational": 0,
             "scoresPrevent": [], "scoresDetect": [],
             "priorityType": [], "priorityUrgency": [],
@@ -142,7 +142,7 @@ def assessmentstats(id):
     for tactic in stats:
         if tactic == "All":
             continue
-        for key in ["Prevented", "Alerted", "Logged", "Missed", "Critical", "High", "Medium", "Low", "Informational"]:
+        for key in ["Prevented and Alerted", "Prevented", "Alerted", "Logged", "Missed", "Critical", "High", "Medium", "Low", "Informational"]:
             stats["All"][key] += stats[tactic][key]
         for key in ["scoresPrevent", "scoresDetect", "priorityType", "priorityUrgency", "controls"]:
             stats["All"][key].extend(stats[tactic][key])
@@ -174,7 +174,8 @@ def assessmenthexagons(id):
             })
             continue
             
-        score = (TestCase.objects(assessmentid=id, tactic=tactics[i], outcome="Prevented").count() +
+        score = (TestCase.objects(assessmentid=id, tactic=tactics[i], outcome="Prevented and Alerted").count() +
+                TestCase.objects(assessmentid=id, tactic=tactics[i], outcome="Prevented").count() +
                 TestCase.objects(assessmentid=id, tactic=tactics[i], outcome="Alerted").count() -
                 TestCase.objects(assessmentid=id, tactic=tactics[i], outcome="Missed").count())
         if score > 1:

--- a/blueprints/assessment_utils.py
+++ b/blueprints/assessment_utils.py
@@ -14,7 +14,7 @@ blueprint_assessment_utils = Blueprint('blueprint_assessment_utils', __name__)
 @roles_accepted('Admin', 'Red', 'Blue')
 @user_assigned_assessment
 def assessmentmulti(id, field):
-    if field not in ["sources", "targets", "tools", "controls", "tags"]:
+    if field not in ["sources", "targets", "tools", "controls", "tags", "preventionsources", "detectionsources"]:
         return '', 418
     
     assessment = Assessment.objects(id=id).first()
@@ -27,6 +27,8 @@ def assessmentmulti(id, field):
             "tools": Tool(),
             "controls": Control(),
             "tags": Tag(),
+            "preventionsources": Preventionsource(),
+            "detectionsources": Detectionsource(),
         }[field]
 
         # If pre-existing, then edit pre-existing to preserve ID

--- a/blueprints/testcase.py
+++ b/blueprints/testcase.py
@@ -63,7 +63,7 @@ def testcasesave(id):
     directFields = ["name", "objective", "actions", "rednotes", "bluenotes", "uuid", "mitreid", "tactic", "state", "prevented", "preventedrating", "alertseverity", "logged", "detectionrating", "priority", "priorityurgency"] if not isBlue else ["bluenotes", "prevented", "alerted", "alertseverity"]
     listFields = ["sources", "targets", "tools", "controls", "tags", "preventionsources", "detectionsources"]
     boolFields = ["alerted", "logged", "visible"] if not isBlue else ["alerted", "logged"]
-    timeFields = ["starttime", "endtime"]
+    timeFields = ["starttime", "endtime", "alerttime", "preventtime"]
     fileFields = ["redfiles", "bluefiles"] if not isBlue else ["bluefiles"]
 
     testcase = applyFormData(testcase, request.form, directFields)

--- a/blueprints/testcase.py
+++ b/blueprints/testcase.py
@@ -43,7 +43,9 @@ def runtestcasepost(id):
             "targets": assessment.targets,
             "tools": assessment.tools,
             "controls": assessment.controls,
-            "tags": assessment.tags
+            "tags": assessment.tags,
+            "preventionsources": assessment.preventionsources,
+            "detectionsources": assessment.detectionsources
         }
     )
 
@@ -59,7 +61,7 @@ def testcasesave(id):
         return ("", 403)
 
     directFields = ["name", "objective", "actions", "rednotes", "bluenotes", "uuid", "mitreid", "tactic", "state", "prevented", "preventedrating", "alertseverity", "logged", "detectionrating", "priority", "priorityurgency"] if not isBlue else ["bluenotes", "prevented", "alerted", "alertseverity"]
-    listFields = ["sources", "targets", "tools", "controls", "tags"]
+    listFields = ["sources", "targets", "tools", "controls", "tags", "preventionsources", "detectionsources"]
     boolFields = ["alerted", "logged", "visible"] if not isBlue else ["alerted", "logged"]
     timeFields = ["starttime", "endtime"]
     fileFields = ["redfiles", "bluefiles"] if not isBlue else ["bluefiles"]

--- a/blueprints/testcase.py
+++ b/blueprints/testcase.py
@@ -60,7 +60,7 @@ def testcasesave(id):
     if not testcase.visible and isBlue:
         return ("", 403)
 
-    directFields = ["name", "objective", "actions", "rednotes", "bluenotes", "uuid", "mitreid", "tactic", "state", "prevented", "preventedrating", "alertseverity", "logged", "detectionrating", "priority", "priorityurgency"] if not isBlue else ["bluenotes", "prevented", "alerted", "alertseverity"]
+    directFields = ["name", "objective", "actions", "rednotes", "bluenotes", "uuid", "mitreid", "tactic", "state", "prevented", "preventedrating", "alertseverity", "logged", "detectionrating", "priority", "priorityurgency", "expectedalertseverity"] if not isBlue else ["bluenotes", "prevented", "alerted", "alertseverity"]
     listFields = ["sources", "targets", "tools", "controls", "tags", "preventionsources", "detectionsources"]
     boolFields = ["alerted", "logged", "visible"] if not isBlue else ["alerted", "logged"]
     timeFields = ["starttime", "endtime", "alerttime", "preventtime"]

--- a/blueprints/testcase.py
+++ b/blueprints/testcase.py
@@ -102,7 +102,10 @@ def testcasesave(id):
         testcase.detecttime = datetime.utcnow()
 
     if testcase.prevented in ["Yes", "Partial"]:
-        testcase.outcome = "Prevented"
+        if testcase.alerted: 
+            testcase.outcome = "Prevented and Alerted"
+        else:
+            testcase.outcome = "Prevented"
     elif testcase.alerted:
         testcase.outcome = "Alerted"
     elif testcase.logged:

--- a/blueprints/testcase_utils.py
+++ b/blueprints/testcase_utils.py
@@ -26,7 +26,7 @@ def testcasevisibility(id):
 def testcaseclone(id):
     orig = TestCase.objects(id=id).first()
     newcase = TestCase()
-    copy = ["name", "assessmentid", "objective", "actions", "rednotes", "mitreid", "uuid", "tactic", "tools", "tags"]
+    copy = ["name", "assessmentid", "objective", "actions", "rednotes", "mitreid", "uuid", "tactic", "tools", "tags", "preventionsources", "detectionsources"]
     for field in copy:
         newcase[field] = orig[field]
     newcase.name = orig["name"] + " (Copy)"

--- a/model.py
+++ b/model.py
@@ -226,7 +226,7 @@ class Assessment(db.Document):
         if testcases == 0:
             return "0|0|0|0|0"
         outcomes = []
-        for outcome in ["Prevented", "Alerted", "Logged", "Missed"]:
+        for outcome in ["Prevented and Alerted", "Prevented", "Alerted", "Logged", "Missed"]:
             outcomes.append(str(round(
                 TestCase.objects(assessmentid=str(self.id), outcome=outcome).count() / 
                 testcases * 100

--- a/model.py
+++ b/model.py
@@ -85,6 +85,31 @@ class Tag(db.EmbeddedDocument):
         }
 
 
+class Preventionsource(db.EmbeddedDocument):    
+    id = db.ObjectIdField( required=True, default=ObjectId )
+    name = db.StringField()
+    description = db.StringField(default="")
+
+    def to_json(self, raw=False):
+        return {
+            "id": str(self.id),
+            "name": esc(self.name, raw),
+            "description": esc(self.description, raw)
+        }
+
+class Detectionsource(db.EmbeddedDocument):    
+    id = db.ObjectIdField( required=True, default=ObjectId )
+    name = db.StringField()
+    description = db.StringField(default="")
+
+    def to_json(self, raw=False):
+        return {
+            "id": str(self.id),
+            "name": esc(self.name, raw),
+            "description": esc(self.description, raw)
+        }
+
+
 class File(db.EmbeddedDocument):
     name = db.StringField()
     path = db.StringField()
@@ -131,6 +156,8 @@ class TestCase(db.Document):
     tools = db.ListField(db.StringField())
     controls = db.ListField(db.StringField())
     tags = db.ListField(db.StringField())
+    preventionsources = db.ListField(db.StringField())
+    detectionsources = db.ListField(db.StringField())
     state = db.StringField(default="Pending")
     prevented = db.StringField()
     preventedrating = db.StringField()
@@ -158,7 +185,7 @@ class TestCase(db.Document):
             jsonDict[field] = esc(self[field], raw)
         for field in ["id", "detecttime", "modifytime", "starttime", "endtime"]:
             jsonDict[field] = str(self[field]).split(".")[0]
-        for field in ["tags", "sources", "targets", "tools", "controls"]:
+        for field in ["tags", "sources", "targets", "tools", "controls", "preventionsources", "detectionsources"]:
             jsonDict[field] = self.to_json_multi(field)
         for field in ["redfiles", "bluefiles"]:
             files = []
@@ -187,6 +214,8 @@ class Assessment(db.Document):
     tools = db.EmbeddedDocumentListField(Tool)
     controls = db.EmbeddedDocumentListField(Control)
     tags = db.EmbeddedDocumentListField(Tag)
+    preventionsources = db.EmbeddedDocumentListField(Preventionsource)
+    detectionsources = db.EmbeddedDocumentListField(Detectionsource)
     navigatorexport = db.StringField(default="")
 
     def get_progress(self):

--- a/model.py
+++ b/model.py
@@ -139,6 +139,9 @@ class TestCaseTemplate(db.Document):
     rednotes = db.StringField(default="")
     uuid = db.StringField(default="")
     provider = db.StringField(default="")
+    priority = db.StringField(default="")    
+    priorityurgency = db.StringField(default="")
+    expectedalertseverity = db.StringField(default="")  
 
 
 class TestCase(db.Document):
@@ -167,6 +170,7 @@ class TestCase(db.Document):
     detectionrating = db.StringField()
     priority = db.StringField()
     priorityurgency = db.StringField()
+    expectedalertseverity = db.StringField()
     starttime = db.DateTimeField()
     endtime = db.DateTimeField()
     detecttime = db.DateTimeField()
@@ -183,7 +187,7 @@ class TestCase(db.Document):
         for field in ["assessmentid", "name", "objective", "actions", "rednotes", "bluenotes",
                       "uuid", "mitreid", "tactic", "state", "prevented", "preventedrating",
                       "alerted", "alertseverity", "logged", "detectionrating",
-                      "priority", "priorityurgency", "visible", "outcome"]:
+                      "priority", "priorityurgency", "expectedalertseverity", "visible", "outcome"]:
             jsonDict[field] = esc(self[field], raw)
         for field in ["id", "detecttime", "modifytime", "starttime", "endtime", "alerttime", "preventtime"]:
             jsonDict[field] = str(self[field]).split(".")[0]

--- a/model.py
+++ b/model.py
@@ -170,6 +170,8 @@ class TestCase(db.Document):
     starttime = db.DateTimeField()
     endtime = db.DateTimeField()
     detecttime = db.DateTimeField()
+    alerttime = db.DateTimeField()
+    preventtime = db.DateTimeField()
     redfiles = db.EmbeddedDocumentListField(File)
     bluefiles = db.EmbeddedDocumentListField(File)
     visible = db.BooleanField(default=False)
@@ -183,7 +185,7 @@ class TestCase(db.Document):
                       "alerted", "alertseverity", "logged", "detectionrating",
                       "priority", "priorityurgency", "visible", "outcome"]:
             jsonDict[field] = esc(self[field], raw)
-        for field in ["id", "detecttime", "modifytime", "starttime", "endtime"]:
+        for field in ["id", "detecttime", "modifytime", "starttime", "endtime", "alerttime", "preventtime"]:
             jsonDict[field] = str(self[field]).split(".")[0]
         for field in ["tags", "sources", "targets", "tools", "controls", "preventionsources", "detectionsources"]:
             jsonDict[field] = self.to_json_multi(field)

--- a/pops-backup.py
+++ b/pops-backup.py
@@ -28,7 +28,7 @@ def exportassessment(assessment, filetype):
     
     # Otherwise flatten JSON arrays into comma delimited strings
     for t, testcase in enumerate(jsonDict):
-        for field in ["sources", "targets", "tools", "controls", "tags", "redfiles", "bluefiles"]:
+        for field in ["sources", "targets", "tools", "controls", "tags", "redfiles", "bluefiles", "preventionsources", "detectionsources"]:
             jsonDict[t][field] = ",".join(testcase[field])
 
     # Convert the JSON dict to CSV and deliver

--- a/pops-backup.py
+++ b/pops-backup.py
@@ -97,34 +97,43 @@ def exportnavigator(id):
         },
         "showTacticRowBackground": True,
         "tacticRowBackground": "#593196",
-        "selectTechniquesAcrossTactics": True,
+        "selectTechniquesAcrossTactics": False,
         "selectSubtechniquesWithParent": False
     }
 
-    for technique in Technique.objects().all():
-        testcases = TestCase.objects(assessmentid=id, mitreid=technique.mitreid).all()
-        ttp = {
-            "techniqueID": technique.mitreid
-        }
+    if current_user.has_role("Blue"):
+        testcases = TestCase.objects(assessmentid=id, visible=True).all()
+    else:
+        testcases = TestCase.objects(assessmentid=id).all()
 
-        if testcases:
+    results = {}
+    for testcase in testcases:
+        if not testcase.tactic in results:
+                results[testcase.tactic] = {}
+        
+        if not testcase.mitreid in results[testcase.tactic]:
+                results[testcase.tactic][testcase.mitreid] = {"Prevented and Alerted": 0, "Prevented": 0, "Alerted": 0, "Logged": 0, "Missed": 0}
+
+        if testcase.outcome in results[testcase.tactic][testcase.mitreid].keys():
+            results[testcase.tactic][testcase.mitreid][testcase.outcome] += 1  
+
+    for tactic_key, techniques in results.items():
+        for technique_key,outcomes in techniques.items():
             count = 0
-            outcomes = {"Prevented": 0, "Alerted": 0, "Logged": 0, "Missed": 0}
-            for testcase in testcases:
-                if testcase.outcome in outcomes.keys():
-                    count += 1
-                    outcomes[testcase.outcome] += 1
+            for outcome_key, outcome in outcomes.items():
+                count += outcome
 
             if count:
-                score = int((outcomes["Prevented"] * 3 + outcomes["Alerted"] * 2 +
-                            outcomes["Logged"]) / (count * 3) * 100)
-                ttp["score"] = score
+                score = int((outcomes["Prevented and Alerted"] * 4 + outcomes["Prevented"] * 3 + outcomes["Alerted"] * 2 +
+                            outcomes["Logged"]) / (count * 4) * 100)
+            
+            ttp = {
+                "techniqueID": technique_key, 
+                "tactic": tactic_key.lower().strip().replace(" ", "-"),
+                "score": score
+            }
+            navigator["techniques"].append(ttp)
 
-            for tactic in technique.tactics:
-                tactic = tactic.lower().strip().replace(" ", "-")
-                tacticTTP = dict(ttp)
-                tacticTTP["tactic"] = tactic
-                navigator["techniques"].append(tacticTTP)
 
     with open(f"{args.backupdir}/{id}/navigator.json", 'w') as f:
         json.dump(navigator, f, indent=4)  

--- a/seeder.py
+++ b/seeder.py
@@ -152,7 +152,10 @@ def parseCustomTestcases ():
             tactic = yml["tactic"],
             objective = yml["objective"],
             actions = yml["actions"],
-            provider = yml["provider"]
+            provider = yml["provider"],
+            priority = yml["priority"],
+            priorityurgency = yml["priorityurgency"],
+            expectedalertseverity = yml["expectedalertseverity"]
         ).save()
 
 def parseCustomKBs ():

--- a/static/scripts/assessment.js
+++ b/static/scripts/assessment.js
@@ -203,7 +203,10 @@ function bgFormatter(value) {
 		bg = "warning"
 	} else if (["Alerted", "3.0", "3.5"].includes(value)) {
 		bg = "success"
-	} else if (["Prevented", "4.0", "4.5", "5.0"].includes(value)) {
+	} else if (["Prevented", "4.0", "4.5"].includes(value)) {
+		bg = "info"
+		text = "light"
+	} else if (["Prevented and Alerted", "5.0"].includes(value)) {
 		bg = "info"
 		text = "light"
 	} else if (["Complete"].includes(value)) {

--- a/static/scripts/assessment.stats.js
+++ b/static/scripts/assessment.stats.js
@@ -83,7 +83,7 @@ var barChartOptionsCustom = {
 	},
 	xaxis: {
 		type: 'category',
-		categories: ["Prevented","Alerted","Logged","Missed"],
+		categories: ["Prevented and Alerted", "Prevented","Alerted","Logged","Missed"],
 		labels: {
                 	show: false,
                 	rotate: -45,
@@ -165,7 +165,7 @@ function boxPlotVals(data) {
 // Outcomes pie chart
 var resultsPie = JSON.parse(JSON.stringify(pieChartOptions));
 resultsPie.title.text = "Outcomes"
-keys = ["Prevented", "Alerted", "Logged", "Missed"]
+keys = ["Prevented and Alerted", "Prevented", "Alerted", "Logged", "Missed"]
 resultsPie.series = keys.map((t) => {
 	return tacticStats["All"][t]
 })
@@ -177,7 +177,7 @@ chart.render();
 // Outcome bar chart (Excluding "All")
 var results = JSON.parse(JSON.stringify(barChartOptions));
 results.title.text = "Outcome per Tactic"
-results.series = ["Prevented", "Alerted", "Logged", "Missed"].map((t) => {
+results.series = ["Prevented and Alerted", "Prevented", "Alerted", "Logged", "Missed"].map((t) => {
 	return {
 		name: t,
 		data: Object.keys(tacticStats).filter((i) => i !== "All").map((i) => {
@@ -272,7 +272,7 @@ function renderTacticChart(name, filteredTacticStats, chartContainerId) {
     results.title.text = name + " Results";
     if (isObjectNotEmpty(filteredTacticStats)) {
             // Loop over each element and set each value from filteredTacticStats
-            results.series = ["Prevented", "Alerted", "Logged", "Missed"].map((t) => {
+            results.series = ["Prevented and Alerted", "Prevented", "Alerted", "Logged", "Missed"].map((t) => {
                 return {
                     name: t,
                     data: [filteredTacticStats[t]] // Put the count of each outcome into an array

--- a/static/scripts/testcase.js
+++ b/static/scripts/testcase.js
@@ -105,11 +105,13 @@ $('input[name="prevented"]').on('change', function() {
 	if (["No", "N/A", ""].includes(current)) {
 		$("#preventedrating").val(current.replace("No", "0.0"))
 		$("#preventedrating-container").hide()
+		$("#preventionsources-container").hide()
 	} else {
 		if (["0.0", "N/A"].includes($("#preventedrating").val())) {
 			$("#preventedrating").val("")
 		}
 		$("#preventedrating-container").show()
+		$("#preventionsources-container").show()
 	}
 }).trigger('change')
 
@@ -133,6 +135,7 @@ $('input[name="alerted"]').on('change', function() {
 	if (current == "Yes") {
 		$("#alert-container").show()
 		$("#detection-container").show()
+		$("#detectionsources-container").show()
 		$("#logged-container").hide()
 		$('input[name="logged"]').prop('checked', false)
 		$('#log-yes').prop("checked", true)
@@ -141,11 +144,13 @@ $('input[name="alerted"]').on('change', function() {
 		}
 	} else if (current == "No") {
 		$("#alert-container").hide()
+		$("#detectionsources-container").hide()
 		$("#alertseverity").val("")
 		$("#logged-container").show()
 		$("#detection-container").hide()
 	} else {
 		$("#alert-container").hide()
+		$("#detectionsources-container").hide()
 		$("#logged-container").hide()
 		$("#detection-container").hide()
 	}

--- a/static/scripts/testcase.js
+++ b/static/scripts/testcase.js
@@ -106,12 +106,14 @@ $('input[name="prevented"]').on('change', function() {
 		$("#preventedrating").val(current.replace("No", "0.0"))
 		$("#preventedrating-container").hide()
 		$("#preventionsources-container").hide()
+		$("#preventiontime-container").hide()
 	} else {
 		if (["0.0", "N/A"].includes($("#preventedrating").val())) {
 			$("#preventedrating").val("")
 		}
 		$("#preventedrating-container").show()
 		$("#preventionsources-container").show()
+		$("#preventiontime-container").show()
 	}
 }).trigger('change')
 
@@ -135,6 +137,7 @@ $('input[name="alerted"]').on('change', function() {
 	if (current == "Yes") {
 		$("#alert-container").show()
 		$("#detection-container").show()
+		$("#alerttime-container").show()
 		$("#detectionsources-container").show()
 		$("#logged-container").hide()
 		$('input[name="logged"]').prop('checked', false)
@@ -144,12 +147,14 @@ $('input[name="alerted"]').on('change', function() {
 		}
 	} else if (current == "No") {
 		$("#alert-container").hide()
+		$("#alerttime-container").hide()
 		$("#detectionsources-container").hide()
 		$("#alertseverity").val("")
 		$("#logged-container").show()
 		$("#detection-container").hide()
 	} else {
 		$("#alert-container").hide()
+		$("#alerttime-container").hide()
 		$("#detectionsources-container").hide()
 		$("#logged-container").hide()
 		$("#detection-container").hide()
@@ -198,6 +203,18 @@ $( document ).ready(function() {
 		endTime = new Date($("#time-end").val());
 		endTime.setMinutes(endTime.getMinutes() - offset * 2);
 		$("#time-end").val(endTime.toISOString().slice(0,16))
+	}
+
+	if ($("#time-alerttime").val()) {
+		endTime = new Date($("#time-alerttime").val());
+		endTime.setMinutes(endTime.getMinutes() - offset * 2);
+		$("#time-alerttime").val(endTime.toISOString().slice(0,16))
+	}
+
+	if ($("#time-preventtime").val()) {
+		endTime = new Date($("#time-preventtime").val());
+		endTime.setMinutes(endTime.getMinutes() - offset * 2);
+		$("#time-preventtime").val(endTime.toISOString().slice(0,16))
 	}
 });
 

--- a/templates/testcase_blue.html
+++ b/templates/testcase_blue.html
@@ -63,10 +63,10 @@
 					</select>
 				</div>
 			</div>
-			<span class="input-group-text text-primary mt-3 rounded-0 rounded-top border-bottom-0">Priority</span>
+			<span class="input-group-text text-primary mt-3 rounded-0 rounded-top border-bottom-0">Expected Result</span>
 			<div class="form-group row m-0 py-2 rounded-bottom" style="border: 1px solid #ededed">
 				<div id="urgency-container" class="row m-0 p-0 my-1">
-					<label for="priorityurgency" class="col-6 col-form-label">Urgency</label>
+					<label for="priorityurgency" class="col-6 col-form-label">Priority</label>
 					<div class="col-6">
 						<select class="form-select p-1" id="priorityurgency" name="priorityurgency" value="{{testcase.priorityurgency or ''}}"{% if current_user.has_role("Blue") %} disabled{% endif %}>
 							<option value="" hidden></option>
@@ -78,7 +78,7 @@
 					</div>
 				</div>
 				<div class="my-1"></div>
-				<label class="col-6 col-form-label">Focus</label>
+				<label class="col-6 col-form-label">State</label>
 				<div class="col-6">
 					<div class="form-check form-check-inline">
 						<input class="form-check-input" type="radio" id="priority-prevent-alert" name="priority" value="Prevent and Alert"
@@ -104,7 +104,7 @@
 				</div>
 				<div class="my-1"></div>
 				<div id="expectedalertseverity-container" class="row m-0 p-0 my-1">
-					<label for="expectedalertseverity" class="col-6 col-form-label">Expected Severity</label>
+					<label for="expectedalertseverity" class="col-6 col-form-label">Severity</label>
 					<div class="col-6">
 						<select class="form-select p-1" id="expectedalertseverity" name="expectedalertseverity" value="{{testcase.expectedalertseverity or ''}}"{% if current_user.has_role("Blue") %} disabled{% endif %}>
 							<option value="" hidden></option>

--- a/templates/testcase_blue.html
+++ b/templates/testcase_blue.html
@@ -39,6 +39,13 @@
 						</select>
 					</div>
 				</div>
+				<div id="preventiontime-container" class="input-group input-group-sm mt-3">
+					<span class="input-group-text text-danger" title="Prevention time">
+						<i class="bi-clock-history">&zwnj;</i>
+					</span>
+					<input type="hidden" name="timezone" id="timezone">
+					<input id='time-preventtime' name="preventtime" type="datetime-local" class='form-control' autocomplete="off" value="{% if testcase.preventtime %}{{ testcase.preventtime.strftime('%Y-%m-%dT%H:%M') }}{% endif %}" {% if current_user.has_role("Spectator") %} disabled{% endif %}>
+				</div>
 				<div id="preventionsources-container" class="input-group input-group-sm mt-3">
 					<span class="input-group-text text-primary" id="preventionsource-label" data-bs-toggle="modal" data-bs-target="#multiPreventionsourceModal"
 						style="cursor:pointer;" title="Manage Prevention Source" >
@@ -146,6 +153,13 @@
 							{% endfor %}
 						</select>
 					</div>
+				</div>
+				<div id="alerttime-container" class="input-group input-group-sm mt-3">
+					<span class="input-group-text text-danger" title="Alert time">
+						<i class="bi-clock-history">&zwnj;</i>
+					</span>
+					<input type="hidden" name="timezone" id="timezone">
+					<input id='time-alerttime' name="alerttime" type="datetime-local" class='form-control' autocomplete="off" value="{% if testcase.alerttime %}{{ testcase.alerttime.strftime('%Y-%m-%dT%H:%M') }}{% endif %}" {% if current_user.has_role("Spectator") %} disabled{% endif %}>
 				</div>
 				<div id="detectionsources-container" class="input-group input-group-sm mt-3">
 					<span class="input-group-text text-primary" id="detectionsource-label" data-bs-toggle="modal" data-bs-target="#multiDetectionsourceModal"

--- a/templates/testcase_blue.html
+++ b/templates/testcase_blue.html
@@ -39,6 +39,22 @@
 						</select>
 					</div>
 				</div>
+				<div id="preventionsources-container" class="input-group input-group-sm mt-3">
+					<span class="input-group-text text-primary" id="preventionsource-label" data-bs-toggle="modal" data-bs-target="#multiPreventionsourceModal"
+						style="cursor:pointer;" title="Manage Prevention Source" >
+						<i class="bi-send">&zwnj;</i>
+					</span>
+					<select class="selectpicker form-control" multiple data-live-search="true" title="Prevention Source(s)"
+						data-style="" data-style-base="form-control-sm form-control"
+						data-live-search-placeholder="Search..." data-width="auto" id="preventionsources"
+						name="preventionsources" autocomplete="off" data-size="10">
+						{% if not current_user.has_role("Spectator") %}<option data-icon="bi-gear">Manage</option>{% endif %}
+						<option data-divider="true"></option>
+						{% for preventionsource in multi.preventionsources %}
+							<option {% if preventionsource.id|string in testcase.preventionsources %}selected{% endif %} class="dynopt-preventionsources" value="{{ preventionsource.id }}">{{ preventionsource.name }}</option>
+						{% endfor %}
+					</select>
+				</div>
 			</div>
 			<span class="input-group-text text-primary mt-3 rounded-0 rounded-top border-bottom-0">Priority</span>
 			<div class="form-group row m-0 py-2 rounded-bottom" style="border: 1px solid #ededed">
@@ -130,6 +146,22 @@
 							{% endfor %}
 						</select>
 					</div>
+				</div>
+				<div id="detectionsources-container" class="input-group input-group-sm mt-3">
+					<span class="input-group-text text-primary" id="detectionsource-label" data-bs-toggle="modal" data-bs-target="#multiDetectionsourceModal"
+						style="cursor:pointer;" title="Manage Detection Source" >
+						<i class="bi-send">&zwnj;</i>
+					</span>
+					<select class="selectpicker form-control" multiple data-live-search="true" title="Detection Source(s)"
+						data-style="" data-style-base="form-control-sm form-control"
+						data-live-search-placeholder="Search..." data-width="auto" id="detectionsources"
+						name="detectionsources" autocomplete="off" data-size="10">
+						{% if not current_user.has_role("Spectator") %}<option data-icon="bi-gear">Manage</option>{% endif %}
+						<option data-divider="true"></option>
+						{% for detectionsource in multi.detectionsources %}
+							<option {% if detectionsource.id|string in testcase.detectionsources %}selected{% endif %} class="dynopt-detectionsources" value="{{ detectionsource.id }}">{{ detectionsource.name }}</option>
+						{% endfor %}
+					</select>
 				</div>
 				<div class="input-group input-group-sm d-none">
 					<span class="input-group-text text-primary">

--- a/templates/testcase_blue.html
+++ b/templates/testcase_blue.html
@@ -65,8 +65,26 @@
 			</div>
 			<span class="input-group-text text-primary mt-3 rounded-0 rounded-top border-bottom-0">Priority</span>
 			<div class="form-group row m-0 py-2 rounded-bottom" style="border: 1px solid #ededed">
+				<div id="urgency-container" class="row m-0 p-0 my-1">
+					<label for="priorityurgency" class="col-6 col-form-label">Urgency</label>
+					<div class="col-6">
+						<select class="form-select p-1" id="priorityurgency" name="priorityurgency" value="{{testcase.priorityurgency or ''}}"{% if current_user.has_role("Blue") %} disabled{% endif %}>
+							<option value="" hidden></option>
+							<option value="N/A" hidden>N/A</option>
+							{% for val in ["Low", "Medium", "High"] %}
+								<option value="{{ val }}" {% if testcase.priorityurgency==val %} selected{% endif%}>{{ val }}</option>
+							{% endfor %}
+						</select>
+					</div>
+				</div>
+				<div class="my-1"></div>
 				<label class="col-6 col-form-label">Focus</label>
 				<div class="col-6">
+					<div class="form-check form-check-inline">
+						<input class="form-check-input" type="radio" id="priority-prevent-alert" name="priority" value="Prevent and Alert"
+							{% if testcase.priority=="Prevent and Alert" %} checked{% endif%}{% if current_user.has_role("Blue") %} disabled{% endif %}>
+						<label class="form-check-label" for="priority-prevent-alert">Prevented & Alerted</label>
+					</div>	
 					<div class="form-check form-check-inline">
 						<input class="form-check-input" type="radio" id="priority-prevent" name="priority" value="Prevent"
 							{% if testcase.priority=="Prevent" %} checked{% endif%}{% if current_user.has_role("Blue") %} disabled{% endif %}>
@@ -85,14 +103,14 @@
 					<input class="form-check-input" type="radio" id="priority-null" name="priority" value=""{% if testcase.priority==none %} checked{% endif%} hidden>
 				</div>
 				<div class="my-1"></div>
-				<div id="urgency-container" class="row m-0 p-0 my-1">
-					<label for="priorityurgency" class="col-6 col-form-label">Urgency</label>
+				<div id="expectedalertseverity-container" class="row m-0 p-0 my-1">
+					<label for="expectedalertseverity" class="col-6 col-form-label">Expected Severity</label>
 					<div class="col-6">
-						<select class="form-select p-1" id="priorityurgency" name="priorityurgency" value="{{testcase.priorityurgency or ''}}"{% if current_user.has_role("Blue") %} disabled{% endif %}>
+						<select class="form-select p-1" id="expectedalertseverity" name="expectedalertseverity" value="{{testcase.expectedalertseverity or ''}}"{% if current_user.has_role("Blue") %} disabled{% endif %}>
 							<option value="" hidden></option>
 							<option value="N/A" hidden>N/A</option>
-							{% for val in ["Low", "Medium", "High"] %}
-								<option value="{{ val }}" {% if testcase.priorityurgency==val %} selected{% endif%}>{{ val }}</option>
+							{% for val in ["Informational", "Low", "Medium", "High", "Critical"] %}
+								<option value="{{ val }}" {% if testcase.expectedalertseverity==val %} selected{% endif%}>{{ val }}</option>
 							{% endfor %}
 						</select>
 					</div>

--- a/templates/testcase_modals.html
+++ b/templates/testcase_modals.html
@@ -29,7 +29,7 @@
 </div>
 {%- endmacro %}
 
-{% for i in ["Source", "Target", "Tool", "Control", "Tag"] %}
+{% for i in ["Source", "Target", "Tool", "Control", "Tag", "Preventionsource", "Detectionsource"] %}
     {{ macros.modalHead(name="multi" ~ i, title="Manage " ~ i ~ "s", xl=True) }}
         {% if i != "Tag" %}
             {{ multiContent(type=i | lower ~ "s") }}


### PR DESCRIPTION
Hello  CyberCX Team

We are looking for a lightweight documentation platform for our Purple Team engagements and came across PurpleOps. I have modified some aspects of PurpleOps for an internal PoC that I think might be of interest to you. Feel free to pick and choose the changes you like.

# 7ed11189806dc02d2e658b3539b0f62cab8741a9
Added autoescaping for exported docx format to avoid breaking the docx XML structure. 

# 0146f9d892150d34e8e1c418d47455ae89b3fc6f
Two new fields added:
- preventionsource
- detectionsource

The general idea is to provide a means of reporting where something has been prevented (e.g. firewall) and where something has been alerted (actually this might be better called alertsource).

# 4583a36d48935435e8f4eed79b001be14a26707a
Added two new time fields:
- preventtime
- alerttime

Idea is to have a means of reporting when an alert or prevention mechanism was triggered. Can be useful to identify large drifts. E.g. something was blocked immediately after execution, but the alert was generated x time later.

# e24284e525625bf39e59d709239b2d31c57ae6c8
Added a new outcome "Prevented and Alerted" as  we often have the case that something is prevented but no alerts are generated.

# dca502cfb9735469de2f19a7a9354a91a5d52aac
I have reworked the mitre attack navigator export function to include the Prevented and Alerted state. I have also changed the logic of how the output is generated. This now allows exports to be generated where a single technique is not selected in every tactic, but only in the specified tactic. So now you can have a T1078.002 in initial access that does not affect the colour/outcome of a T1078.002 test in persistence.

# b697a4c4f8239e145a301c254b00949ff3008511
Added a new field:
- expectedalertseverity

The red team can now define what kind of alert severity they expect from a particular test. This helps to detect drifts between expected and actual alerts. I also added the priority, priorityurgency and expectedalertseverity to the exports/templates functions. So when you define a test, you can set the expected result in the template.

# 2153343ee65175cf0efc07090aaeb82adbcb54aa
Adapts the wording in the testcase_blue files to the idea above.

# thats it

I hope this helps.
Let me know if something is unclear

Cheers and thanks for the great tool!