### PR TITLE
atomic T1652 empty input args case

### DIFF
--- a/seeder.py
+++ b/seeder.py
@@ -126,7 +126,7 @@ def parseAtomicRedTeam ():
                 baseCommand = artTestcase["executor"]["command"].strip()
                 # If there's variables in the command, populate it with the
                 # default sample variables e.g. #{dumpname} > lsass.dmp
-                if "input_arguments" in artTestcase:
+                if "input_arguments" in artTestcase and isinstance(artTestcase["input_arguments"], dict):
                     for i in artTestcase["input_arguments"].keys():
                         k = "#{" + i + "}"
                         baseCommand = baseCommand.replace(k, str(artTestcase["input_arguments"][i]["default"]))


### PR DESCRIPTION
Atomic red team has added T1652 which has an empty input_arguments attribute. POPS did not handle the case where input_arguments existed but was empty.