### PR TITLE
Security improvements to docker deployment

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
-MONGO_DB=assessments3
+MONGO_DB=assessments
 MONGO_HOST=mongodb
 MONGO_PORT=27017
 
-FLASK_DEBUG=True
+FLASK_DEBUG=False
 FLASK_MFA=False
 
 HOST=0.0.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,7 @@ supervisord.pid
 sampledata/sigma/*
 external/*
 INITIAL_ADMIN_PASSWORD.TXT
+
+# Certs for SSL
+*.crt
+*.key

--- a/compose.yml
+++ b/compose.yml
@@ -34,7 +34,7 @@ services:
       - 80:80
       - 443:443
     volumes:
-      - ./nginx/custom_certs:/etc/nginx/ssl
+      - ./nginx/certs:/etc/nginx/ssl
     depends_on:
       - purpleops
     networks:

--- a/compose.yml
+++ b/compose.yml
@@ -1,19 +1,20 @@
-version: '3.8'
-
 services:
   mongodb:
     image: mongo:7.0-rc
     container_name: mongodb
     ports:
-      - 27017
+      - 127.0.0.1:27017:27017
     volumes:
       - mongodb_data:/data/db
+    networks:
+      - app-network
+
   purpleops:
     build: .
     container_name: purpleops
-    command: gunicorn --bind 0.0.0.0:5000 purpleops:app
+    command: gunicorn --bind 0.0.0.0:5000 --forwarded-allow-ips="*" purpleops:app
     ports:
-      - "5000:5000"
+      - '127.0.0.1:5000:5000'
     env_file:
       - ./.env
     depends_on:
@@ -21,6 +22,28 @@ services:
     volumes:
       - purpleops_data:/usr/src/app/
       - ./custom:/usr/src/app/custom
+    networks:
+      - app-network
+
+  nginx:
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
+    container_name: nginx
+    ports:
+      - '80:80'
+      - '443:443'
+    volumes:
+      - ./nginx/custom_certs:/etc/nginx/ssl
+    depends_on:
+      - purpleops
+    networks:
+      - app-network
+
 volumes:
   mongodb_data:
   purpleops_data:
+
+networks:
+  app-network:
+    driver: bridge

--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,7 @@ services:
     container_name: purpleops
     command: gunicorn --bind 0.0.0.0:5000 --forwarded-allow-ips="*" purpleops:app
     ports:
-      - '127.0.0.1:5000:5000'
+      - 127.0.0.1:5000:5000
     env_file:
       - ./.env
     depends_on:
@@ -31,8 +31,8 @@ services:
       dockerfile: Dockerfile
     container_name: nginx
     ports:
-      - '80:80'
-      - '443:443'
+      - 80:80
+      - 443:443
     volumes:
       - ./nginx/custom_certs:/etc/nginx/ssl
     depends_on:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,31 @@
+FROM nginx:alpine
+
+# Install OpenSSL
+RUN apk add --no-cache openssl
+
+# Set working directory
+WORKDIR /etc/nginx
+
+# Create ssl directory
+# RUN mkdir -p /etc/nginx/ssl
+
+# Generate self-signed certificate
+# RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+#     -keyout /etc/nginx/ssl/nginx.key -out /etc/nginx/ssl/nginx.crt \
+#     -subj "/C=US/ST=State/L=City/O=Organization/CN=localhost"
+
+# Copy a script to handle certificate generation or use
+COPY generate_or_use_cert.sh /usr/src/app/
+RUN chmod +x /usr/src/app/generate_or_use_cert.sh
+
+# Copy nginx configuration
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Expose port 443
+EXPOSE 443
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/src/app/generate_or_use_cert.sh"]
+
+# Start Nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -6,14 +6,6 @@ RUN apk add --no-cache openssl
 # Set working directory
 WORKDIR /etc/nginx
 
-# Create ssl directory
-# RUN mkdir -p /etc/nginx/ssl
-
-# Generate self-signed certificate
-# RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-#     -keyout /etc/nginx/ssl/nginx.key -out /etc/nginx/ssl/nginx.crt \
-#     -subj "/C=US/ST=State/L=City/O=Organization/CN=localhost"
-
 # Copy a script to handle certificate generation or use
 COPY generate_or_use_cert.sh /usr/src/app/
 RUN chmod +x /usr/src/app/generate_or_use_cert.sh

--- a/nginx/generate_or_use_cert.sh
+++ b/nginx/generate_or_use_cert.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ ! -f "/etc/nginx/ssl/nginx.crt" ] || [ ! -f "/etc/nginx/ssl/nginx.key" ]; then
+    echo "Generating self-signed certificates"
+    mkdir -p /etc/nginx/ssl
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+        -keyout /etc/nginx/ssl/nginx.key -out /etc/nginx/ssl/nginx.crt \
+        -subj "/C=US/ST=State/L=City/O=Organization/CN=purpleops"
+else
+    echo "Nginx SSL certificates already exist"
+fi
+
+# Execute the CMD
+exec "$@"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,24 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 80;
+        listen 443 ssl;
+        server_name localhost;
+
+        ssl_certificate /etc/nginx/ssl/nginx.crt;
+        ssl_certificate_key /etc/nginx/ssl/nginx.key;
+
+        location / {
+            proxy_pass http://purpleops:5000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            # proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            # proxy_set_header X-Forwarded-Host $server_name;
+            # proxy_set_header X-Forwarded-Port $server_port;
+        }
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -4,7 +4,8 @@ events {
 
 http {
     server {
-        listen 80;
+        # uncomment to listen on port 80
+        # listen 80;
         listen 443 ssl;
         server_name localhost;
 
@@ -15,10 +16,7 @@ http {
             proxy_pass http://purpleops:5000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            # proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            # proxy_set_header X-Forwarded-Host $server_name;
-            # proxy_set_header X-Forwarded-Port $server_port;
         }
     }
 }


### PR DESCRIPTION
- Added reverse proxy to forward 443 to 5000.
- Updated app services to bind to localhost, only exposing reverse proxy to the host.
- Added self-signed cert generation.
- Added ability to use custom certs. Simply create a directory called certs in the nginx directory, and add cert (nginx.crt) and key (nginx.key) to it.