### PR TITLE
Add restart policy to services in compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -2,6 +2,7 @@ version: '3.8'
 
 services:
   mongodb:
+    restart: always
     image: mongo:7.0-rc
     container_name: mongodb
     ports:
@@ -9,6 +10,7 @@ services:
     volumes:
       - mongodb_data:/data/db
   purpleops:
+    restart: always
     build: .
     container_name: purpleops
     command: gunicorn --bind 0.0.0.0:5000 purpleops:app

--- a/compose.yml
+++ b/compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - mongodb_data:/data/db
   purpleops:
-    restart: always
+    restart: unless-stopped
     build: .
     container_name: purpleops
     command: gunicorn --bind 0.0.0.0:5000 purpleops:app

--- a/compose.yml
+++ b/compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   mongodb:
-    restart: always
+    restart: unless-stopped
     image: mongo:7.0-rc
     container_name: mongodb
     ports:


### PR DESCRIPTION
Added restart policy to mongodb and purpleops services since currently the containers need to be manually brought back up after a Docker daemon or host restart.